### PR TITLE
修复在通过数据库连接，上传流量使用量时的倍率问题

### DIFF
--- a/db_transfer.py
+++ b/db_transfer.py
@@ -113,7 +113,7 @@ class DbTransfer(object):
             cur.close()
 
             bandwidth_thistime = bandwidth_thistime + \
-                ((dt_transfer[id][0] + dt_transfer[id][1]) * self.traffic_rate)
+                (dt_transfer[id][0] + dt_transfer[id][1])
 
             if query_sub_in is not None:
                 query_sub_in += ',%s' % id


### PR DESCRIPTION
例如，当节点倍率设置为0.1时，用户A跑了1G流量
修复前：实际使用1G，用户A计费100M，节点使用量增加0.1G
修复后：实际使用1G，用户A计费100M，节点使用量增加1G